### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/sergeygrishin/d7fea377-9dd2-4dd2-93b0-37212bd23ca8/56f41f8c-9460-40e5-aa64-6d8354dca359/_apis/work/boardbadge/df23a299-5ce2-48ab-b20b-5ad76accb9bd)](https://dev.azure.com/sergeygrishin/d7fea377-9dd2-4dd2-93b0-37212bd23ca8/_boards/board/t/56f41f8c-9460-40e5-aa64-6d8354dca359/Microsoft.RequirementCategory)
 # Prod1
 The first product ...
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#8](https://dev.azure.com/sergeygrishin/d7fea377-9dd2-4dd2-93b0-37212bd23ca8/_workitems/edit/8). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.